### PR TITLE
Added comments on meeting length and workdays

### DIFF
--- a/additional.html
+++ b/additional.html
@@ -120,11 +120,14 @@
 
                 <h2>Transit</h2>
                 <p>Provide clear text and image instructions on how to get to the conference venue (and other relevant conference locations, e.g. if participants will be staying at a designated hotel). Make sure these instructions are print-friendly (and not just a link to a Google Map). Try to know in advance whether any participants have mobility needs and will require alternative transportation arrangements (e.g. arranging for a shuttle between hotel and venue, booking a hotel closer to the venue, etc.) This information can be collected in the conference registration form, or in a pre-conference email.
+
                   <br></br>
                 </p>
 
                 <h2>Choosing Conference Dates</h2>
                 <p>Although many Western organizers generally avoid scheduling events or conferences on traditionally Christian holidays, such as Easter or Christmas, organizers should also be mindful of religious holidays and observances for non-Christian religions as well.
+                </p>
+                <p>In choosing dates you may also want to consider how the length of meeting may affect the ability of particular groups to attend. Those with caring obligations may not be able to leave home for extended periods. Also consider how your choice of how the meeting lies across workdays and weekends might affect attendees. Particularly in communities where there are many volunteers some may only be able to attend outside regular working times. Equally, other attendees wishing to maintain a work/life balance may not be able to attend outside working times. There are no simply solutions where communities are mixed, however the potential for inclusion and exclusion can be considered.
                   <br></br>
                 </p>
 


### PR DESCRIPTION
Relates to issue #11 

Suggested changes under Choosing Conference Dates to address issues of conference length and the ability of some participants to attend or not outside of regular working times. A related change could be made to the checklist if this change is considered appropriate.